### PR TITLE
communities.json: spellfix for Wiesbaden

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -144,7 +144,7 @@
   "Malmö": [
     "http://gateway-01.mesh.pjodd.se/hopglass/nodes.json"
   ],
-  "Mainz/Wiebsaden": [
+  "Mainz/Wiesbaden": [
     "https://map.freifunk-mwu.de/data/meshviewer.json"
   ],
   "München": [


### PR DESCRIPTION
> Freifunk in Mainz, Wiesbaden und Umgebung

_as found on https://freifunk-mwu.de_ 