### PR TITLE
communities.json: Nord: replace broken url

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -170,7 +170,7 @@
     "https://map.freifunk-niersufer.de/data/meshviewer.json"
   ],
   "Nord": [
-    "https://mesh.freifunknord.de/data/meshviewer.json",
+    "https://map.freifunknord.de/data/nodes.json",
     "https://mesh.freifunknord.de/iz/meshviewer.json",
     "https://mesh.freifunknord.de/ploh/meshviewer.json"
   ],


### PR DESCRIPTION
it seems like neither URL contains all nodes, but the nodes.json and the two
meshviewer.json do contain quite a few duplicates