### PR TITLE
Fix counting for communities which use multiple URLs

### DIFF
--- a/census-exporter.py
+++ b/census-exporter.py
@@ -203,11 +203,11 @@ def main(outfile):
                 base = match.group("base")
                 metric_gluon_version_total.labels(
                     community=community, version=version, base=base
-                ).set(sum)
+                ).inc(sum)
             for model, sum in models.items():
                 metric_gluon_model_total.labels(
                     community=community, model=model
-                ).set(sum)
+                ).inc(sum)
 
     write_to_textfile(outfile, registry)
 


### PR DESCRIPTION
For instance for the Winterberg community, which uses multiple meshviewer.json URLs, the result in Gluon Census would wrongly be shown as only around ~170 nodes, even though their map says "1006 nodes online". Also census-exporter.py says this for Winterberg:

```
  ...
  1166 unique nodes
  3 duplicates skipped
```

However the resulting gluon-census.prom will only have around 170 for Winterberg.

The issue is that if one URL sets this for instance:

```
  "base="gluon-v2020.1.3",community="Winterberg",version="gluon-v2020.1.3"
```

Then a later URL can provide an entry with the same labels and this later URL would wrongly override the numbers of the previously parsed URL.

To fix this, add the numbers instead of overwriting them.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>