### PR TITLE
Collect used vpn types from communities

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -3,10 +3,10 @@
     "https://map03.4830.org/data/nodes.json"
   ],
   "Aachen": [
-    "https://map.aachen.freifunk.net/data/meshviewer.json"
+    "https://map.aachen.freifunk.net/data/nodes.json"
   ],
   "Altdorf": [
-    "https://map.tecff.de/yanic/meshviewer.json"
+    "https://map.tecff.de/yanic/nodes.json"
   ],
   "Ansbach": [
     "https://karte.freifunk-ansbach.de/data/nodes.json"
@@ -15,17 +15,17 @@
     "http://map.freifunk-bochum.de:4000/nodes.json"
   ],
   "Braunschweig": [
-    "https://freifunk-bs.de/data/meshviewer.json"
+    "https://freifunk-bs.de/data/nodes.json"
   ],
   "Bremen": [
-    "https://downloads.bremen.freifunk.net/data/meshviewer.json"
+    "https://downloads.bremen.freifunk.net/data/nodes.json"
   ],
   "Chemnitz": [
     "https://descartes.chemnitz.freifunk.net/nodes.json",
     "https://brewster.chemnitz.freifunk.net/nodes.json"
   ],
   "Darmstadt": [
-    "https://meshviewer.darmstadt.freifunk.net/data/meshviewer.json"
+    "https://meshviewer.darmstadt.freifunk.net/data/nodes.json"
   ],
   "Divonet": [
     "https://map.divonet.de/data/sn04-netsplit/meshviewer.json"
@@ -37,46 +37,46 @@
     "https://map.ffdo.de/data/nodes.json"
   ],
   "Dreiländereck": [
-    "https://map.freifunk-3laendereck.net/data/meshviewer.json"
+    "https://map.freifunk-3laendereck.net/data/nodes.json"
   ],
   "Dresden": [
     "https://meshviewer.freifunk-dresden.de/data/nodes.json"
   ],
   "Düsseldorf": [
-    "https://map.freifunk-duesseldorf.de/data/meshviewer.json"
+    "https://map.freifunk-duesseldorf.de/data/nodes.json"
   ],
   "Eulenfunk": [
     "https://map.eulenfunk.de/data/nodes.json"
   ],
   "Einbeck": [
-    "https://map.freifunkeinbeck.de/yanic/meshviewer.json"
+    "https://map.freifunkeinbeck.de/yanic/nodes.json"
   ],
   "Emskirchen": [
     "https://karte.freifunk-emskirchen.de/data/nodes.json"
   ],
   "Erfurt": [
-    "https://map.erfurt.freifunk.net/meshviewer/data/meshviewer.json"
+    "https://map.erfurt.freifunk.net/meshviewer/data/nodes.json"
   ],
   "Essen": [
-    "https://map.freifunk-essen.de/data/meshviewer.json"
+    "https://map.freifunk-essen.de/data/nodes.json"
   ],
   "Ennepe-Ruhr": [
     "https://karte.ff-en.de/data/meshviewer.json"
   ],
   "Frankfurt": [
-    "https://yanic.batman15.ffffm.net/meshviewer.json"
+    "https://yanic.batman15.ffffm.net/nodes.json"
   ],
   "Fulda": [
     "https://meshviewer.fulda.freifunk.net/data/meshviewer.json"
   ],
   "Gera-Greiz": [
-    "https://www.freifunk-gera-greiz.de/meshviewer/data/meshviewer.json"
+    "https://www.freifunk-gera-greiz.de/meshviewer/data/nodes.json"
   ],
   "Göttingen": [
-    "https://map.cccgoe.de/data/meshviewer.json"
+    "https://map.cccgoe.de/data/nodes.json"
   ],
   "Greifswald": [
-    "https://map.ffhgw.de/data/meshviewer.json",
+    "https://map.ffhgw.de/data/nodes.json",
     "https://unifi.greifswald.freifunk.net/data/meshviewer.json"
   ],
   "Groß-Gerau": [
@@ -89,7 +89,7 @@
     "https://hopglass-backend.hamburg.freifunk.net/nodes.json"
   ],
   "Harz": [
-    "https://map.harz.freifunk.net/data/meshviewer.json"
+    "https://map.harz.freifunk.net/data/nodes.json"
   ],
   "Hannover": [
     "https://hannover.freifunk.net/api/nodes.json"
@@ -104,10 +104,10 @@
     "https://map.hochstift.freifunk.net/data/nodes.json"
   ],
   "Ingolstadt": [
-    "https://map.freifunk-ingolstadt.de/yanic/meshviewer.json"
+    "https://map.freifunk-ingolstadt.de/yanic/nodes.json"
   ],
   "Karlsruhe": [
-    "https://api.karlsruhe.freifunk.net/yanic/meshviewer/meshviewer.json"
+    "https://api.karlsruhe.freifunk.net/yanic/meshviewer/nodes.json"
   ],
   "Kiel": [
     "https://hopglass.freifunk.in-kiel.de/nodes.json"
@@ -122,7 +122,7 @@
     "https://map.fflev.de/data/meshviewer.json"
   ],
   "Lippe": [
-    "https://map.freifunk-lippe.de/map/data/meshviewer.json"
+    "https://map.freifunk-lippe.de/map/data/nodes.json"
   ],
   "Lübeck": [
     "https://map.luebeck.freifunk.net/data/nodes.json"
@@ -131,7 +131,7 @@
     "http://gateway-01.mesh.pjodd.se/hopglass/nodes.json"
   ],
   "Mainz/Wiesbaden": [
-    "https://map.freifunk-mwu.de/data/meshviewer.json"
+    "https://map.freifunk-mwu.de/data/nodes.json"
   ],
   "Marburg": [
     "https://api.marburg.freifunk.net/nodes.json"
@@ -140,7 +140,7 @@
     "https://map.ffmuc.net/data/meshviewer.json"
   ],
   "Mayen-Koblenz": [
-    "https://map.freifunk-myk.de/data/meshviewer.json"
+    "https://map.freifunk-myk.de/data/nodes.json"
   ],
   "Münsterland": [
     "https://karte.freifunk-muensterland.de/data/nodes.json"
@@ -156,20 +156,20 @@
   ],
   "Nord": [
     "https://map.freifunknord.de/data/nodes.json",
-    "https://mesh.freifunknord.de/iz/meshviewer.json",
+    "https://mesh.freifunknord.de/iz/nodes.json",
     "https://mesh.freifunknord.de/ploh/meshviewer.json"
   ],
   "Nordheide": [
     "https://map02.freifunk-nordheide.de/data/meshviewer.json"
   ],
   "Nordhessen": [
-    "https://map.freifunk-nordhessen.de/data/meshviewer.json"
+    "https://map.freifunk-nordhessen.de/data/nodes.json"
   ],
   "Nordwest": [
     "https://map.ffnw.de/data/meshviewer.json"
   ],
   "Ostholstein": [
-    "https://coco.ffoh.de/meshviewer/data/meshviewer.json"
+    "https://coco.ffoh.de/meshviewer/data/nodes.json"
   ],
   "Pinneberg": [
     "https://meshviewer.pinneberg.freifunk.net/data/nodes.json"
@@ -181,27 +181,27 @@
     "https://map.freifunk-rheinbach.de/data/nodes.json"
   ],
   "Rhein-Neckar": [
-    "https://map.ffrn.de/data/meshviewer.json"
+    "https://map.ffrn.de/data/nodes.json"
   ],
   "Rhein-Sieg": [
-    "https://map.freifunk-rhein-sieg.net/data/lohmar1/domain01/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/lohmar1/domain03/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/lohmar2/domain05/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain04/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain07/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain11/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain01/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain03/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain04/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/niederkassel2/domain05/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/siegburg1/domain01/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/siegburg2/domain02/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/siegburg2/domain05/meshviewer.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar1/domain01/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar1/domain03/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar2/domain05/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain04/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain07/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/lohmar3/domain11/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain01/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain03/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/niederkassel1/domain04/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/niederkassel2/domain05/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/siegburg1/domain01/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/siegburg2/domain02/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/siegburg2/domain05/nodes.json",
     "https://map.freifunk-rhein-sieg.net/data/tdf/all/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/tdf4/tdf/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/tdf5/inn/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/tdf6/flu/meshviewer.json",
-    "https://map.freifunk-rhein-sieg.net/data/voreifel1/domain15/meshviewer.json"
+    "https://map.freifunk-rhein-sieg.net/data/tdf4/tdf/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/tdf5/inn/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/tdf6/flu/nodes.json",
+    "https://map.freifunk-rhein-sieg.net/data/voreifel1/domain15/nodes.json"
   ],
   "Roenkhausen": [
     "https://map.roenkhausen.de/meshviewer/data/meshviewer.json"
@@ -210,16 +210,16 @@
     "https://netmon.freifunk-rothenburg.de/meshviewer/data/meshviewer.json"
   ],
   "Ruhrgebiet": [
-    "https://map.freifunk.ruhr/data/rgw/meshviewer.json"
+    "https://map.freifunk.ruhr/data/rgw/nodes.json"
   ],
   "Saarland": [
     "https://mgmt.saar.freifunk.net/data/nodes.json"
   ],
   "Südholstein": [
-    "https://map.freifunk-suedholstein.de/data/meshviewer.json"
+    "https://map.freifunk-suedholstein.de/data/nodes.json"
   ],
   "Südpfalz": [
-    "https://new.freifunk-suedpfalz.de/netzausbau/data/meshviewer.json"
+    "https://new.freifunk-suedpfalz.de/netzausbau/data/nodes.json"
   ],
   "Südwest": [
     "https://services.freifunk-suedwest.de/hopglass/nodes.json"
@@ -228,13 +228,13 @@
     "https://map.freifunk-stuttgart.de/data/meshviewer.json"
   ],
   "Trier": [
-    "http://maps.tackin.de/data/meshviewer.json"
+    "http://maps.tackin.de/data/nodes.json"
   ],
   "Troisdorf": [
     "https://map.freifunk-troisdorf.de/data/api/meshviewer.json"
   ],
   "Tuttlingen": [
-    "https://map.freifunk-3laendereck.net/map-data/fftut/meshviewer.json"
+    "https://map.freifunk-3laendereck.net/map-data/fftut/nodes.json"
   ],
   "Uelzen": [
     "https://map.freifunk-uelzen.de/data/nodes.json"
@@ -243,10 +243,10 @@
     "https://map.freifunk-ulm.de/data/meshviewer.json"
   ],
   "Vogtland": [
-    "https://mapdata.freifunk-vogtland.net/meshviewer.json"
+    "https://mapdata.freifunk-vogtland.net/nodes.json"
   ],
   "Westpfalz": [
-    "https://api.karlsruhe.freifunk.net/yanic/meshviewer/ffwp/meshviewer.json"
+    "https://api.karlsruhe.freifunk.net/yanic/meshviewer/ffwp/nodes.json"
   ],
   "Winterberg": [
     "https://map.freifunk-winterberg.net/data/ar/meshviewer.json",

--- a/contrib/switch-to-nodesJson.py
+++ b/contrib/switch-to-nodesJson.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import json
+import requests
+import structlog
+
+def download(url, timeout=5):
+    return requests.get(url, timeout=timeout)
+
+log = structlog.get_logger()
+
+def main():
+    # Open and load the JSON file
+    with open('communities.json', 'r') as f:
+        data = json.load(f)
+
+    # Iterate over the JSON object
+    for community, urls in data.items():
+        for i, url in enumerate(urls):
+            urlSplit = url.rsplit('/', 1)
+
+            # check assumption
+            if urlSplit[1] not in ['nodes.json', 'meshviewer.json']:
+                log.msg(f"{community}: The URL doesn't contain a supported filename, skipping", url=url)
+                continue
+
+            # get url without file
+            urlPath = urlSplit[0]
+
+            # Send a GET request to test whether nodes.json is available
+            urlTest = urlPath + '/nodes.json'
+            try:
+                response = download(urlTest)
+            except requests.exceptions.RequestException as e:
+                response.status_code = -1
+
+            # Check the status code of the response
+            if response.status_code == 200:
+                print(f'{community}: OK: nodes.json available')
+                data[community][i] = urlTest
+            else:
+                # nodes.json is not available, try meshviewer.json
+                urlTest = urlPath + '/meshviewer.json'
+                try:
+                    response = download(urlTest)
+                    if response.status_code == 200:
+                        data[community][i] = urlTest
+                        print(f'{community}: Fallback: meshviewer.json available')
+                    else:
+                        # neither is available, print error and keep the original URL
+                        log.msg(f"'{community}: Unexpected HTTP status code", status_code=response.status_code, url=url)
+                except requests.exceptions.RequestException as e:
+                    # neither is reachable, print error and keep the original URL
+                    log.msg(f"{community}: Exception caught while fetching {urlTest}", ex=e)
+
+    print('\nDone. Writing to communities.json')
+    with open('communities.json', 'w') as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Found these changes i had made some time ago.

the PR is only for documentation in case one wants to dive into it at some point in the future

---

unfortunately so far only a rather limited amount of data this produces

```
gluon_vpn_total{community="4830.org",vpn="tunneldigger"} 488.0
gluon_vpn_total{community="Ansbach",vpn="fastd"} 176.0
gluon_vpn_total{community="Bochum",vpn="fastd"} 282.0
gluon_vpn_total{community="Chemnitz",vpn="fastd"} 245.0
gluon_vpn_total{community="Dreiländereck",vpn="fastd"} 1998.0
gluon_vpn_total{community="Eulenfunk",vpn="fastd"} 179.0
gluon_vpn_total{community="Eulenfunk",vpn="tunneldigger"} 884.0
gluon_vpn_total{community="Emskirchen",vpn="fastd"} 13.0
gluon_vpn_total{community="Halle",vpn="fastd"} 91.0
gluon_vpn_total{community="Hamburg",vpn="fastd"} 715.0
gluon_vpn_total{community="Heilsbronn",vpn="fastd"} 18.0
gluon_vpn_total{community="Kiel",vpn="fastd"} 15.0
gluon_vpn_total{community="Lübeck",vpn="fastd"} 244.0
gluon_vpn_total{community="Münsterland",vpn="tunneldigger"} 3821.0
gluon_vpn_total{community="Neuendettelsau",vpn="fastd"} 19.0
gluon_vpn_total{community="Neustadt-Aisch",vpn="fastd"} 19.0
gluon_vpn_total{community="Saarland",vpn="tunneldigger"} 710.0
gluon_vpn_total{community="Südwest",vpn="tunneldigger"} 994.0
gluon_vpn_total{community="Südwest",vpn="None"} 1.0
```