### PR TITLE
Communities cleanup v2

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -183,8 +183,7 @@
   ],
   "Nord": [
     "https://map.freifunknord.de/data/nodes.json",
-    "https://mesh.freifunknord.de/iz/meshviewer.json",
-    "https://mesh.freifunknord.de/ploh/meshviewer.json"
+    "https://mesh.freifunknord.de/iz/meshviewer.json"
   ],
   "Nordheide": [
     "https://map02.freifunk-nordheide.de/data/meshviewer.json"

--- a/communities.json
+++ b/communities.json
@@ -120,9 +120,6 @@
   "Heilsbronn": [
     "https://karte.freifunk-heilsbronn.de/data/nodes.json"
   ],
-  "Hennef": [
-    "https://map.freifunk-hennef.de/data/nodes.json"
-  ],
   "Hochstift": [
     "https://map.hochstift.freifunk.net/data/nodes.json"
   ],


### PR DESCRIPTION
This is part 2. Still work in progress.
Feel free to debate already.
Hennef Nodes are still running albeit on old firmware and the infrastructure is in dire need of being maintained.
About Ploh: I mailed Freifunk Nord to figure out why Ploh is down.

Missing changes:
- Freifunk Hochstift offers a meshviewer.json per domain. nodes.json merges all domains. Which one do we prefer? Switch over to meshviewer.json would add more URLs to crawl.
- Eulenfunk should be splitted into the actual communities since the supplied nodes.json is created by a cronjob that hasn't been updated/changed and doesn't contain all Communities: Neanderfunk, MK, Siegerland, Wuppertal, maybe more. Siegerland only switched recently and is now being hosted by Neanderfunk: https://siegerland.freifunk.net/2024/05/22/2024-05-22-abschaltung-der-alten-technik-ab-juni/ This change would replace one nodes.json to crawl by 30 or 40 nodes.json files :/