### PR TITLE
communities.json: drop Leipzig

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -142,9 +142,6 @@
   "Kitzingen": [
     "https://falterturm.freifunk-vec.de/meshviewer.json"
   ],
-  "Leipzig": [
-    "http://karte.leipzig.freifunk.net:8018/meshviewer2/data/meshviewer.json"
-  ],
   "Leverkusen": [
     "https://map.fflev.de/data/meshviewer.json"
   ],


### PR DESCRIPTION
> they switched from Gluon to OpenWrt based images
> Only 3 Gluon devices are left.
> new domain:
> https://freifunk-leipzig.de