### PR TITLE
communities.json: drop Uelzen

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -244,9 +244,6 @@
   "Tuttlingen": [
     "https://map.freifunk-3laendereck.net/map-data/fftut/meshviewer.json"
   ],
-  "Uelzen": [
-    "https://map.freifunk-uelzen.de/data/nodes.json"
-  ],
   "Vogtland": [
     "https://mapdata.freifunk-vogtland.net/meshviewer.json"
   ],


### PR DESCRIPTION
> 4830.org adopted those nodes and they now appear on their map