### PR TITLE
Add 2500 nodes with non-standard (Gluon) version numbers

### DIFF
--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -36,6 +36,11 @@ PATTERNS: list[PatternDef] = [
         "base": re.compile(r"^(?P<base>gluon-v\d{4}\.\d(?:\.\d)?).*"),
         "vtype": "gluon-base",
     },
+    {
+        "version": re.compile(r"^(?P<version>gluon-unknown)$"),
+        "base": re.compile(r"^(?P<base>gluon-unknown)$"),
+        "vtype": "gluon-unknown",
+    },
 ]
 
 

--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -41,6 +41,11 @@ PATTERNS: list[PatternDef] = [
         "base": re.compile(r"^(?P<base>gluon-unknown)$"),
         "vtype": "gluon-unknown",
     },
+    {
+        "version": re.compile(r"^(?P<version>gluon-[0-9a-f]{7,})$"),
+        "base": re.compile(r"^(?P<base>gluon-[0-9a-f]{7,})$"),
+        "vtype": "gluon-commitid",
+    },
 ]
 
 

--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -27,6 +27,9 @@ VERSION_PATTERN = re.compile(r"^(?P<version>gluon-v\d{4}\.\d(?:\.\d)?(?:-\d+)?).
 BASE_PATTERN = re.compile(r"^(?P<base>gluon-v\d{4}\.\d(?:\.\d)?).*")
 
 seen = set()
+total_version_sum = 0
+total_model_sum = 0
+total_domain_sum = 0
 duplicates = 0
 
 
@@ -211,6 +214,7 @@ def named_load(
 @click.command(short_help="Collect census information")
 @click.argument("outfile", default="./gluon-census.prom")
 def main(outfile: str) -> None:
+    global total_version_sum, total_model_sum, total_domain_sum
     registry = CollectorRegistry()
     metric_gluon_version_total = Gauge(
         "gluon_base_total",
@@ -257,17 +261,26 @@ def main(outfile: str) -> None:
                 version=version,
                 base=base,
             ).inc(version_sum)
+            total_version_sum += version_sum
         for model, model_sum in result.models.items():
             metric_gluon_model_total.labels(community=community, model=model).inc(
                 model_sum,
             )
+            total_model_sum += model_sum
         for domain, domain_sum in result.domains.items():
             metric_gluon_domain_total.labels(community=community, domain=domain).inc(
                 domain_sum,
             )
+            total_domain_sum += domain_sum
 
     write_to_textfile(outfile, registry)
 
+    log.msg(
+        "Collections summaries",
+        version_sum=total_version_sum,
+        model_sum=total_model_sum,
+        domain_sum=total_domain_sum,
+    )
     log.msg("Summary", unique=len(seen), duplicate=duplicates)
 
 

--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -46,6 +46,11 @@ PATTERNS: list[PatternDef] = [
         "base": re.compile(r"^(?P<base>gluon-[0-9a-f]{7,})$"),
         "vtype": "gluon-commitid",
     },
+    {
+        "version": re.compile(r"^(?P<version>gluon-.*)"),
+        "base": re.compile(r"^(?P<base>gluon-.*)"),
+        "vtype": "gluon-custom",
+    },
 ]
 
 


### PR DESCRIPTION
This adds around 1250 Gluon nodes which have some slightly "unconventional" version strings. Which, even though their Gluon base cannot be determined, are still clearly Gluon nodes.

For a bit more control on graph creation with these nodes included the extra label "vtype" is added. So if one would like to keep a graph as is, with these new nodes excluded, one can filter for a `vtype="gluon-base"` label. The new nodes are using a `vtype="gluon-unknown"`, `vtype="gluon-commitid"` and `vtype="gluon-custom"` label. See the respective Git commits for details.

Furthermore, this adds around 1250 nodes which do not run Gluon, but which still announce themselves to the Gluon census exporter. These are mainly Debian/Ubuntu/NixOS systems. But also OpenWrt routers from Freifunk Dresden. To ignore these nodes in graphs, one can filter them out via the new `vtype="foreign"` label. And some announce no version at all, these can be filtered out via the new `vtype="undefined"`.