### PR TITLE
exporter: add empty domain_codes and site_codes

### DIFF
--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -163,7 +163,10 @@ def parse_meshviewer(
                 base = None
             version = get_version(base)
             result.bases[version] += 1
-            model = normalize_model_name(node["model"])
+            try:
+                model = normalize_model_name(node["model"])
+            except KeyError:
+                model = ""
             result.models[model] += 1
             try:
                 domain = node["domain"]
@@ -189,6 +192,7 @@ def parse_nodes_json_v1(
             base = None
         version = get_version(base)
         result.bases[version] += 1
+        result.models[""] += 1
         result.domains[("", "")] += 1
     return result
 
@@ -208,7 +212,10 @@ def parse_nodes_json_v2(
                 base = None
             version = get_version(base)
             result.bases[version] += 1
-            model = normalize_model_name(node["nodeinfo"]["hardware"]["model"])
+            try:
+                model = normalize_model_name(node["nodeinfo"]["hardware"]["model"])
+            except KeyError:
+                model = ""
             result.models[model] += 1
             try:
                 domain = node["nodeinfo"]["system"]["domain_code"]

--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -293,6 +293,28 @@ def named_load(
     return (community_name, result)
 
 
+def check_node_counts() -> None:
+    if total_version_sum + total_alien_sum != len(seen):
+        log.error(
+            "Node count mismatch",
+            unique=len(seen),
+            version_sum=total_version_sum,
+            alien_sum=total_alien_sum,
+        )
+    if total_model_sum != len(seen):
+        log.error(
+            "Model count mismatch",
+            unique=len(seen),
+            model_sum=total_model_sum,
+        )
+    if total_domain_sum != len(seen):
+        log.error(
+            "Domain count mismatch",
+            unique=len(seen),
+            domain_sum=total_domain_sum,
+        )
+
+
 @click.command(short_help="Collect census information")
 @click.argument("outfile", default="./gluon-census.prom")
 def main(outfile: str) -> None:
@@ -386,6 +408,8 @@ def main(outfile: str) -> None:
         domain_sum=total_domain_sum,
     )
     log.msg("Summary", unique=len(seen), duplicate=duplicates)
+
+    check_node_counts()
 
 
 if __name__ == "__main__":

--- a/src/gluon_census_exporter/__main__.py
+++ b/src/gluon_census_exporter/__main__.py
@@ -155,27 +155,27 @@ def parse_meshviewer(
     for node in data["nodes"]:
         try:
             node_id = node["node_id"]
-            if already_seen(node_id):
-                continue
-            try:
-                base = node["firmware"]["base"]
-            except KeyError:
-                base = None
-            version = get_version(base)
-            result.bases[version] += 1
-            try:
-                model = normalize_model_name(node["model"])
-            except KeyError:
-                model = ""
-            result.models[model] += 1
-            try:
-                domain = node["domain"]
-            except KeyError:
-                domain = ""
-            site = ""
-            result.domains[(site, domain)] += 1
         except KeyError:
             continue
+        if already_seen(node_id):
+            continue
+        try:
+            base = node["firmware"]["base"]
+        except KeyError:
+            base = None
+        version = get_version(base)
+        result.bases[version] += 1
+        try:
+            model = normalize_model_name(node["model"])
+        except KeyError:
+            model = ""
+        result.models[model] += 1
+        try:
+            domain = node["domain"]
+        except KeyError:
+            domain = ""
+        site = ""
+        result.domains[(site, domain)] += 1
     return result
 
 
@@ -204,30 +204,30 @@ def parse_nodes_json_v2(
     for node in data["nodes"]:
         try:
             node_id = node["nodeinfo"]["node_id"]
-            if already_seen(node_id):
-                continue
-            try:
-                base = node["nodeinfo"]["software"]["firmware"]["base"]
-            except KeyError:
-                base = None
-            version = get_version(base)
-            result.bases[version] += 1
-            try:
-                model = normalize_model_name(node["nodeinfo"]["hardware"]["model"])
-            except KeyError:
-                model = ""
-            result.models[model] += 1
-            try:
-                domain = node["nodeinfo"]["system"]["domain_code"]
-            except KeyError:
-                domain = ""
-            try:
-                site = node["nodeinfo"]["system"]["site_code"]
-            except KeyError:
-                site = ""
-            result.domains[(site, domain)] += 1
         except KeyError:
             continue
+        if already_seen(node_id):
+            continue
+        try:
+            base = node["nodeinfo"]["software"]["firmware"]["base"]
+        except KeyError:
+            base = None
+        version = get_version(base)
+        result.bases[version] += 1
+        try:
+            model = normalize_model_name(node["nodeinfo"]["hardware"]["model"])
+        except KeyError:
+            model = ""
+        result.models[model] += 1
+        try:
+            domain = node["nodeinfo"]["system"]["domain_code"]
+        except KeyError:
+            domain = ""
+        try:
+            site = node["nodeinfo"]["system"]["site_code"]
+        except KeyError:
+            site = ""
+        result.domains[(site, domain)] += 1
     return result
 
 

--- a/tests/integration/test_census_exporter.py
+++ b/tests/integration/test_census_exporter.py
@@ -82,8 +82,11 @@ def test_fixed_main(httpserver: HTTPServer, meshviewer_data: dict) -> None:
             content = p.read()
             for total, amount in (
                 ("gluon_base_total{", 7),
-                ("gluon_model_total{", 110),
-                ("gluon_domain_total{", 21),
+                ("gluon_model_total{", 109),
+                ("gluon_domain_total{", 20),
+                ("gluon_alien_total{", 1),
+                ("gluon_alien_model_total{", 1),
+                ("gluon_alien_domain_total{", 11),
             ):
                 assert content.count(total) == amount
 


### PR DESCRIPTION
It currently seems a bit wild regarding who sets or doesn't set the domain_code and/or site_code.

So it seems that for now we would need to consider the tuple of (domain_code, site_code) as a unique identifier of a broadcast domain of a community, with each potentially being empty.